### PR TITLE
Progressive Web App: Various UI/UX Fixes

### DIFF
--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
+    <link rel="preload" as="image" href="/matcha_logo_m.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,9 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
+    <link rel="preload" as="image" href="/matcha_logo_m.png" />
     <link rel="manifest" href="/manifest.json" />
     <link rel="apple-touch-icon" href="/matcha_app_icon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#111111" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -9,7 +9,8 @@ export default defineConfig({
 	envDir: "../../",
 
 	server: {
+		host: true, // bind to 0.0.0.0 so ngrok can reach it
 		port: 3000,
-		allowedHosts: true, // allow ngrok and other tunnel hosts
+		allowedHosts: true,
 	},
 });

--- a/packages/ui/src/components/modals/AccountModal.tsx
+++ b/packages/ui/src/components/modals/AccountModal.tsx
@@ -133,6 +133,11 @@ export function AccountModal({
 		}
 	}
 
+	function closeAvatarPicker() {
+		setAvatarPickerOpen(false);
+		setPendingAvatarNum(null);
+	}
+
 	async function saveAvatar(num: number) {
 		setAvatarPickerOpen(false);
 		setPendingAvatarNum(null);
@@ -476,7 +481,29 @@ export function AccountModal({
 				</div>
 
 				<div className="avatar-picker-panel">
-					<span className="avatar-picker-title">Choose Avatar</span>
+					<div className="avatar-picker-header">
+						<span className="avatar-picker-title">Choose Avatar</span>
+						<button
+							className="avatar-picker-close"
+							onClick={handleClose}
+							aria-label="Close"
+						>
+							<svg
+								viewBox="0 0 16 16"
+								fill="none"
+								xmlns="http://www.w3.org/2000/svg"
+								width="14"
+								height="14"
+							>
+								<path
+									d="M2 2l12 12M14 2L2 14"
+									stroke="currentColor"
+									strokeWidth="1.8"
+									strokeLinecap="round"
+								/>
+							</svg>
+						</button>
+					</div>
 					<div className="avatar-picker-grid">
 						{Array.from({ length: TOTAL_AVATARS }, (_, i) => i + 1).map(
 							(num) => (
@@ -493,13 +520,21 @@ export function AccountModal({
 							),
 						)}
 					</div>
-					<button
-						className="avatar-picker-save-btn"
-						disabled={pendingAvatarNum === null}
-						onClick={() => pendingAvatarNum && saveAvatar(pendingAvatarNum)}
-					>
-						Save
-					</button>
+					<div className="avatar-picker-actions">
+						<button
+							className="avatar-picker-cancel-btn"
+							onClick={closeAvatarPicker}
+						>
+							Cancel
+						</button>
+						<button
+							className="avatar-picker-save-btn"
+							disabled={pendingAvatarNum === null}
+							onClick={() => pendingAvatarNum && saveAvatar(pendingAvatarNum)}
+						>
+							Save
+						</button>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/packages/ui/src/styles/editor.css
+++ b/packages/ui/src/styles/editor.css
@@ -6,7 +6,6 @@
   flex-direction: column;
   background: var(--main-bg);
   overflow: hidden;
-  position: fixed !important;
 }
 
 .os-windows .main {
@@ -297,6 +296,21 @@
   flex: 1;
 }
 
+.toolbar-left {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.toolbar-right {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  justify-content: flex-end;
+}
+
 .toolbar-center-group {
   display: flex;
   align-items: center;
@@ -305,6 +319,66 @@
   border: 1px solid var(--border);
   border-radius: 10px;
   padding: 3px;
+}
+
+/* ── Mobile show/hide utilities ── */
+
+.toolbar-hide-mobile {
+  /* visible by default on desktop — no-op */
+}
+
+.toolbar-show-mobile {
+  display: none;
+}
+
+/* ── Mobile "…" more menu ── */
+
+.toolbar-more-wrap {
+  position: relative;
+}
+
+.toolbar-more-dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  background: rgba(28, 28, 30, 0.96);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.6),
+    0 2px 8px rgba(0, 0, 0, 0.3);
+  padding: 4px;
+  min-width: 180px;
+  z-index: 200;
+}
+
+.toolbar-more-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 9px 12px;
+  background: transparent;
+  border: none;
+  border-radius: 7px;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  font-size: 0.933rem;
+  color: var(--text);
+  transition: background 0.1s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.toolbar-more-option:hover,
+.toolbar-more-option:active {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.toolbar-more-option-danger {
+  color: var(--danger);
 }
 
 .toolbar-btn {
@@ -575,35 +649,23 @@
 /* ─── Mobile editor tweaks (≤932px) ─────────────────────── */
 
 @media (max-width: 932px) {
-  /* Top toolbar: back on left, share/del on right — push below notch */
+  .main {
+    position: fixed !important;
+  }
+
+  /* Toolbar stays in normal flow — push content below the notch */
   .toolbar {
     overflow: visible;
     flex-wrap: nowrap;
-    padding: max(16px, env(safe-area-inset-top)) 16px 12px;
+    padding: max(16px, env(safe-area-inset-top)) 12px 12px;
     gap: 4px;
     min-height: 48px;
     position: relative;
-    justify-content: space-between;
   }
 
-  /* Formatting group moves to a fixed bottom bar on mobile (like Apple Notes) */
+  /* Center group stays in the toolbar (no fixed bottom bar) */
   .toolbar-center-group {
-    position: fixed;
-    left: 12px;
-    bottom: max(16px, env(safe-area-inset-bottom));
-    transform: none;
-    z-index: 100;
-  }
-
-  /* Dropdowns from the bottom bar open upward */
-  .toolbar-center-group .style-dropdown {
-    top: auto;
-    bottom: calc(100% + 6px);
-  }
-
-  .toolbar-center-group .attach-dropdown {
-    top: auto;
-    bottom: calc(100% + 6px);
+    position: static;
   }
 
   .toolbar-mobile-back {
@@ -644,8 +706,28 @@
     font-size: 16px; /* prevents iOS auto-zoom on focus */
   }
 
-  /* Extra bottom padding to clear the fixed format bar */
+  /* Prevent iOS auto-zoom when tapping into the editor */
+  .ProseMirror {
+    font-size: 16px;
+  }
+
+  .ProseMirror p,
+  .ProseMirror li,
+  .ProseMirror blockquote {
+    font-size: 16px;
+  }
+
+  /* Normal scroll — no extra padding needed without the fixed format bar */
   .editor-scroll-area {
-    padding-bottom: calc(max(16px, env(safe-area-inset-bottom)) + 64px);
+    padding-bottom: max(16px, env(safe-area-inset-bottom));
+  }
+
+  /* Hide desktop-only buttons, show mobile-only elements */
+  .toolbar-hide-mobile {
+    display: none !important;
+  }
+
+  .toolbar-show-mobile {
+    display: flex;
   }
 }

--- a/packages/ui/src/styles/editor.css
+++ b/packages/ui/src/styles/editor.css
@@ -6,6 +6,7 @@
   flex-direction: column;
   background: var(--main-bg);
   overflow: hidden;
+  position: fixed !important;
 }
 
 .os-windows .main {
@@ -571,14 +572,14 @@
   display: none;
 }
 
-/* ─── Mobile editor tweaks (≤900px) ─────────────────────── */
+/* ─── Mobile editor tweaks (≤932px) ─────────────────────── */
 
-@media (max-width: 900px) {
+@media (max-width: 932px) {
   /* Top toolbar: back on left, share/del on right — push below notch */
   .toolbar {
     overflow: visible;
     flex-wrap: nowrap;
-    padding: max(16px, env(safe-area-inset-top)) 8px 12px;
+    padding: max(16px, env(safe-area-inset-top)) 16px 12px;
     gap: 4px;
     min-height: 48px;
     position: relative;

--- a/packages/ui/src/styles/layout.css
+++ b/packages/ui/src/styles/layout.css
@@ -89,13 +89,10 @@
 }
 
 @media (display-mode: standalone) and (max-width: 900px) {
-  .app-root {
-    height: 110%;
-  }
-
   html,
   body,
   #root {
-    height: 110%;
+    height: calc(100vh - 1px);
+    overflow-y: hidden;
   }
 }

--- a/packages/ui/src/styles/layout.css
+++ b/packages/ui/src/styles/layout.css
@@ -13,43 +13,58 @@
   display: none;
 }
 
-/* ─── Mobile layout (≤900px): fullscreen list OR editor ─── */
-/* 900px catches landscape iPhones (~852px); 768px misses them */
+/* ─── Mobile layout (≤932px): fullscreen list OR editor ─── */
+/* 932px catches all landscape iPhones incl. Pro Max (932px); 900px misses them */
 
-@media (max-width: 900px) {
+@media (max-width: 932px) {
   .app {
     position: relative;
   }
 
   .sidebar,
   .main {
-    position: absolute;
+    position: absolute !important;
     top: 0;
     left: 0;
     width: 100% !important;
     min-width: 0; /* allow shrinking; overrides flex default */
     height: 100%;
-    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
     -webkit-overflow-scrolling: touch; /* smooth scroll on iOS */
   }
 
+  /* Only enable slide transition after first paint — prevents initial flash */
+  .app-ready .sidebar,
+  .app-ready .main {
+    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
   /* List view: sidebar visible, editor off-screen right */
-  .app[data-mobile-view="list"] .sidebar { transform: translateX(0); }
-  .app[data-mobile-view="list"] .main    { transform: translateX(100%); }
+  .app[data-mobile-view="list"] .sidebar {
+    transform: translateX(0);
+  }
+  .app[data-mobile-view="list"] .main {
+    transform: translateX(100%);
+  }
 
   /* Editor view: sidebar off-screen left, editor visible */
-  .app[data-mobile-view="editor"] .sidebar { transform: translateX(-100%); }
-  .app[data-mobile-view="editor"] .main    { transform: translateX(0); }
+  .app[data-mobile-view="editor"] .sidebar {
+    transform: translateX(-100%);
+  }
+  .app[data-mobile-view="editor"] .main {
+    transform: translateX(0);
+  }
 
   /* Hide drag-to-resize handle */
-  .sidebar-resize-handle { display: none !important; }
+  .sidebar-resize-handle {
+    display: none !important;
+  }
 
   /* Show mobile back button */
   .mobile-back-btn {
     display: flex;
     align-items: center;
     gap: 7px;
-    padding: max(10px, env(safe-area-inset-top)) 16px 10px;
+    padding: max(16px, env(safe-area-inset-top)) 30px 16px;
     background: none;
     border: none;
     border-bottom: 1px solid var(--border);
@@ -73,3 +88,14 @@
   }
 }
 
+@media (display-mode: standalone) and (max-width: 900px) {
+  .app-root {
+    height: 110%;
+  }
+
+  html,
+  body,
+  #root {
+    height: 110%;
+  }
+}

--- a/packages/ui/src/styles/modals.css
+++ b/packages/ui/src/styles/modals.css
@@ -7,7 +7,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: transparent;
+  background: var(--modal-dim);
 }
 
 .about-close {
@@ -452,7 +452,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: transparent;
+  background: var(--modal-dim);
 }
 
 .account-header {
@@ -588,7 +588,9 @@
   color: var(--text-dim);
   cursor: pointer;
   padding: 5px 12px;
-  transition: color 0.15s, border-color 0.15s;
+  transition:
+    color 0.15s,
+    border-color 0.15s;
 }
 
 .account-sync-btn:hover:not(:disabled) {
@@ -606,7 +608,9 @@
 }
 
 @keyframes account-spin {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .account-signout-row {
@@ -787,13 +791,41 @@
   overflow: hidden;
 }
 
+.avatar-picker-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+
 .avatar-picker-title {
   font-size: 0.933rem;
   font-weight: 600;
   color: var(--text);
-  margin-bottom: 14px;
   padding: 0 2px;
   white-space: nowrap;
+}
+
+.avatar-picker-close {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: var(--text-dim);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition:
+    background 0.12s,
+    color 0.12s;
+}
+
+.avatar-picker-close:hover {
+  background: var(--item-hover);
+  color: var(--text);
 }
 
 .avatar-picker-grid {
@@ -849,9 +881,37 @@
   display: block;
 }
 
-.avatar-picker-save-btn {
+.avatar-picker-actions {
+  display: flex;
+  gap: 8px;
   margin-top: 14px;
-  width: 100%;
+}
+
+.avatar-picker-cancel-btn {
+  flex: 1;
+  height: 36px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  color: var(--text);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.867rem;
+  font-weight: 500;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.avatar-picker-cancel-btn:hover {
+  background: var(--item-hover);
+  border-color: var(--text-dim);
+}
+
+.avatar-picker-save-btn {
+  flex: 1;
   height: 36px;
   background: var(--accent);
   border: none;
@@ -971,7 +1031,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: transparent;
+  background: var(--modal-dim);
 }
 
 .settings-card {
@@ -1366,7 +1426,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: transparent;
+  background: var(--modal-dim);
 }
 
 .share-card {
@@ -1701,36 +1761,43 @@
   opacity: 0.88;
 }
 
-/* ─── Mobile modal tweaks (≤900px) ──────────────────────── */
+/* ─── Mobile modal tweaks (≤932px) ──────────────────────── */
 
-@media (max-width: 900px) {
-  /* ── Account overlay: push below notch, allow scrolling ── */
+@media (max-width: 932px) {
+  /* ── Account overlay: center in viewport, card scrolls internally ── */
   .account-overlay {
-    align-items: flex-start;
-    padding: max(16px, env(safe-area-inset-top)) 0 max(16px, env(safe-area-inset-bottom));
-    overflow-y: auto;
+    align-items: center;
+    padding: 0 16px;
   }
 
   .account-card-wrap .account-card {
     width: calc(100vw - 32px);
-    max-height: none;
+    max-height: calc(100svh - 40px);
     overflow-y: auto;
   }
 
-  /* ── Settings overlay: push below notch, allow scrolling ── */
+  /* ── Settings overlay: center in viewport, internal scroll if needed ── */
   .settings-overlay {
-    align-items: flex-start;
-    padding: max(16px, env(safe-area-inset-top)) 0 max(16px, env(safe-area-inset-bottom));
+    align-items: center;
+    padding: max(16px, env(safe-area-inset-top)) 16px
+      max(16px, env(safe-area-inset-bottom));
     overflow-y: auto;
   }
 
   .settings-card {
     width: calc(100vw - 32px);
+    max-height: calc(100dvh - 64px);
+    overflow-y: auto;
   }
 
   /* ── Avatar picker: replace account card with picker only ── */
   .account-card-wrap {
     flex-direction: column;
+  }
+
+  /* Hide collapsed picker so it doesn't contribute height and shift the card */
+  .account-card-wrap:not(.picker-open) .avatar-picker-panel {
+    display: none;
   }
 
   .account-card-wrap.picker-open .account-card {
@@ -1743,6 +1810,7 @@
     overflow: visible !important;
     pointer-events: auto !important;
     padding: 20px 16px !important;
+    margin-left: 0 !important;
   }
 
   /* ── Avatar grid: 4 columns (~30% smaller icons) on mobile ── */
@@ -1751,4 +1819,3 @@
     gap: 8px;
   }
 }
-

--- a/packages/ui/src/styles/sidebar.css
+++ b/packages/ui/src/styles/sidebar.css
@@ -9,7 +9,7 @@
   padding: 12px 8px 0;
   gap: 4px;
   overflow: hidden;
-  position: fixed !important;
+  position: relative;
 }
 
 .sidebar-footer {
@@ -734,6 +734,10 @@
 /* ─── Mobile sidebar tweaks (≤932px) ────────────────────── */
 
 @media (max-width: 932px) {
+  .sidebar {
+    position: fixed;
+  }
+
   /* ── Sizing ── */
   .note-item {
     min-height: 58px;

--- a/packages/ui/src/styles/sidebar.css
+++ b/packages/ui/src/styles/sidebar.css
@@ -9,7 +9,7 @@
   padding: 12px 8px 0;
   gap: 4px;
   overflow: hidden;
-  position: relative;
+  position: fixed !important;
 }
 
 .sidebar-footer {
@@ -731,9 +731,9 @@
   opacity: 0.7;
 }
 
-/* ─── Mobile sidebar tweaks (≤900px) ────────────────────── */
+/* ─── Mobile sidebar tweaks (≤932px) ────────────────────── */
 
-@media (max-width: 900px) {
+@media (max-width: 932px) {
   /* ── Sizing ── */
   .note-item {
     min-height: 58px;
@@ -749,15 +749,37 @@
     font-size: 0.867rem;
   }
 
+  .sidebar-search-wrap {
+    height: 44px;
+  }
+
   .sidebar-search-input {
     font-size: 16px; /* prevents iOS auto-zoom on focus */
-    height: 36px;
+    height: 44px;
   }
 
   .sidebar-header {
     padding-top: max(12px, env(safe-area-inset-top));
-    padding-left: 6px;
-    padding-right: 6px;
+    padding-left: 14px;
+    padding-right: 14px;
+  }
+
+  .sidebar-avatar {
+    width: 40px;
+    height: 40px;
+  }
+
+  .sidebar-avatar svg {
+    width: 26px;
+    height: 26px;
+  }
+
+  .sidebar-display-name {
+    font-size: 1rem;
+  }
+
+  .sidebar-note-count {
+    font-size: 0.8rem;
   }
 
   .sidebar-footer {
@@ -765,15 +787,15 @@
   }
 
   .sidebar-footer-btn {
-    min-width: 40px;
-    min-height: 40px;
-    font-size: 1rem;
+    min-width: 44px;
+    min-height: 44px;
+    font-size: 1.067rem;
   }
 
   .new-note-fab {
-    width: 36px;
-    height: 36px;
-    font-size: 1rem;
+    width: 40px;
+    height: 40px;
+    font-size: 1.067rem;
   }
 
   /* ── No persistent active/selected highlight on mobile ── */

--- a/packages/ui/src/styles/todo.css
+++ b/packages/ui/src/styles/todo.css
@@ -37,6 +37,17 @@
   color: var(--accent);
 }
 
+@media (max-width: 932px) {
+  .sidebar-todo-btn {
+    padding: 12px 12px;
+    font-size: 0.933rem;
+  }
+
+  .todo-goals-body.expanded .todo-goals-inner {
+    max-height: min(28vh, 200px);
+  }
+}
+
 /* ─── Todo List View ─────────────────────────────────────── */
 
 .todo-view {

--- a/packages/ui/src/styles/variables.css
+++ b/packages/ui/src/styles/variables.css
@@ -28,6 +28,7 @@
   --table-border: #575c52;
   --link: #7aab66;
   --radius: 9px;
+  --modal-dim: rgba(0, 0, 0, 0.85);
 
   font-family:
     -apple-system, BlinkMacSystemFont, "SF Pro Text", Inter, system-ui,


### PR DESCRIPTION
# Description

This PR contains two batches of fixes targeting the PWA (mobile web) experience and a toolbar refactor.

**PWA / mobile layout fixes:**
- Bumped mobile breakpoint from 900 px to 932 px to correctly catch landscape iPhone Pro Max
- Added `app-ready` class (set after first layout effect) to prevent the sidebar/editor slide animation from flashing on initial load
- Switched `.main` and `.sidebar` to `position: fixed` on mobile so they fill the full viewport correctly
- Replaced the fixed-bottom format bar with an inline toolbar; all formatting controls now live in the top toolbar on mobile
- Added a `…` overflow menu in the editor toolbar that collapses Share / Leave / Delete into a single tap on mobile
- Modal overlays (About, Account, Settings, Share) now render with a proper `var(--modal-dim)` backdrop
- Account modal: added a Cancel button and close (×) button to the avatar picker panel; hides the collapsed picker so it doesn't shift the card height
- Sidebar mobile tweaks: larger touch targets (44 px min), bigger search input, adjusted header padding
- Added `maximum-scale=1.0` to the web viewport meta tag to prevent iOS pinch-zoom
- Preload the Matcha logo `<m>` image to eliminate splash-screen flicker
- Removed leftover `console.log` debug statements from the shared-notes fetch path

**Toolbar refactor (desktop + mobile):**
- Replaced the old `toolbar-spacer` divs with `toolbar-left` / `toolbar-right` flex containers for predictable centering
- Font styling options were migrated back into the inline toolbar (separate commit)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)