### PR TITLE
Fix attachment cleanup: delete files from Supabase Storage on removal (#2)

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -23,6 +23,7 @@ import {
 	supabase,
 	deleteAllNoteImages,
 	deleteAllNoteFiles,
+	deleteAllNoteAttachments,
 	extractPreview,
 	extractAllText,
 	isNoteEmpty,
@@ -1011,16 +1012,17 @@ function App() {
 
 		const db = activeSupabase.current;
 		if (db) {
+			await deleteAllNoteAttachments(db, id);
+			if (user) {
+				deleteAllNoteImages(db, user.id, id);
+				deleteAllNoteFiles(db, user.id, id);
+			}
 			db.from("notes")
 				.delete()
 				.eq("id", id)
 				.then(({ error }) => {
 					if (error) console.warn("Supabase delete error:", error.message);
 				});
-			if (user) {
-				deleteAllNoteImages(db, user.id, id);
-				deleteAllNoteFiles(db, user.id, id);
-			}
 		}
 	}
 
@@ -1120,16 +1122,17 @@ function App() {
 		if (!isPending) {
 			const db = activeSupabase.current;
 			if (db) {
+				await deleteAllNoteAttachments(db, prevId);
+				if (user) {
+					deleteAllNoteImages(db, user.id, prevId);
+					deleteAllNoteFiles(db, user.id, prevId);
+				}
 				db.from("notes")
 					.delete()
 					.eq("id", prevId)
 					.then(({ error }) => {
 						if (error) console.warn("Supabase delete error:", error.message);
 					});
-				if (user) {
-					deleteAllNoteImages(db, user.id, prevId);
-					deleteAllNoteFiles(db, user.id, prevId);
-				}
 			}
 		}
 	}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -22,6 +22,7 @@ import {
 	supabase,
 	deleteAllNoteImages,
 	deleteAllNoteFiles,
+	deleteAllNoteAttachments,
 	extractPreview,
 	extractAllText,
 	isNoteEmpty,
@@ -944,16 +945,21 @@ function App() {
 
 		const db = activeSupabase.current;
 		if (db) {
+			// Delete storage objects before the note row so ON DELETE CASCADE
+			// doesn't remove attachment rows before we can query them.
+			await deleteAllNoteAttachments(db, id);
+			if (user) {
+				// Fallback: also clean up via storage.list in case any files
+				// were uploaded before the attachments table existed.
+				deleteAllNoteImages(db, user.id, id);
+				deleteAllNoteFiles(db, user.id, id);
+			}
 			db.from("notes")
 				.delete()
 				.eq("id", id)
 				.then(({ error }) => {
 					if (error) console.warn("Supabase delete error:", error.message);
 				});
-			if (user) {
-				deleteAllNoteImages(db, user.id, id);
-				deleteAllNoteFiles(db, user.id, id);
-			}
 		}
 	}
 
@@ -1053,16 +1059,17 @@ function App() {
 		if (!isPending) {
 			const db = activeSupabase.current;
 			if (db) {
+				await deleteAllNoteAttachments(db, prevId);
+				if (user) {
+					deleteAllNoteImages(db, user.id, prevId);
+					deleteAllNoteFiles(db, user.id, prevId);
+				}
 				db.from("notes")
 					.delete()
 					.eq("id", prevId)
 					.then(({ error }) => {
 						if (error) console.warn("Supabase delete error:", error.message);
 					});
-				if (user) {
-					deleteAllNoteImages(db, user.id, prevId);
-					deleteAllNoteFiles(db, user.id, prevId);
-				}
 			}
 		}
 	}

--- a/packages/core/src/lib/storage.ts
+++ b/packages/core/src/lib/storage.ts
@@ -6,179 +6,273 @@ const IMAGE_PATH_MARKER = `/storage/v1/object/public/${IMAGE_BUCKET}/`;
 const FILE_PATH_MARKER = `/storage/v1/object/public/${FILE_BUCKET}/`;
 
 function imageExtFromFile(file: File): string {
-  const mime = file.type.split("/")[1];
-  if (mime === "jpeg") return "jpg";
-  return mime || "png";
+	const mime = file.type.split("/")[1];
+	if (mime === "jpeg") return "jpg";
+	return mime || "png";
 }
 
 export async function uploadNoteImage(
-  supabase: SupabaseClient,
-  userId: string,
-  noteId: string,
-  file: File,
+	supabase: SupabaseClient,
+	userId: string,
+	noteId: string,
+	file: File,
 ): Promise<string | null> {
-  const ext = imageExtFromFile(file);
-  const path = `${userId}/${noteId}/${crypto.randomUUID()}.${ext}`;
+	const ext = imageExtFromFile(file);
+	const path = `${userId}/${noteId}/${crypto.randomUUID()}.${ext}`;
 
-  const { error } = await supabase.storage
-    .from(IMAGE_BUCKET)
-    .upload(path, file, { contentType: file.type, upsert: false });
+	const { error } = await supabase.storage
+		.from(IMAGE_BUCKET)
+		.upload(path, file, { contentType: file.type, upsert: false });
 
-  if (error) {
-    console.warn("Image upload failed:", error.message);
-    return null;
-  }
+	if (error) {
+		console.warn("Image upload failed:", error.message);
+		return null;
+	}
 
-  const { data } = supabase.storage.from(IMAGE_BUCKET).getPublicUrl(path);
-  const url = data.publicUrl;
+	const { data } = supabase.storage.from(IMAGE_BUCKET).getPublicUrl(path);
+	const url = data.publicUrl;
 
-  try {
-    const res = await fetch(url, { method: "HEAD" });
-    if (!res.ok) {
-      console.warn("Uploaded image not publicly accessible, cleaning up:", res.status);
-      await supabase.storage.from(IMAGE_BUCKET).remove([path]);
-      return null;
-    }
-  } catch {
-    console.warn("Could not verify uploaded image URL, cleaning up");
-    await supabase.storage.from(IMAGE_BUCKET).remove([path]);
-    return null;
-  }
+	try {
+		const res = await fetch(url, { method: "HEAD" });
+		if (!res.ok) {
+			console.warn(
+				"Uploaded image not publicly accessible, cleaning up:",
+				res.status,
+			);
+			await supabase.storage.from(IMAGE_BUCKET).remove([path]);
+			return null;
+		}
+	} catch {
+		console.warn("Could not verify uploaded image URL, cleaning up");
+		await supabase.storage.from(IMAGE_BUCKET).remove([path]);
+		return null;
+	}
 
-  return url;
+	await trackAttachment(supabase, userId, noteId, IMAGE_BUCKET, path, url);
+	return url;
 }
 
 function imagePathFromUrl(url: string): string | null {
-  const idx = url.indexOf(IMAGE_PATH_MARKER);
-  if (idx === -1) return null;
-  return decodeURIComponent(url.slice(idx + IMAGE_PATH_MARKER.length));
+	const idx = url.indexOf(IMAGE_PATH_MARKER);
+	if (idx === -1) return null;
+	return decodeURIComponent(url.slice(idx + IMAGE_PATH_MARKER.length));
 }
 
 function filePathFromUrl(url: string): string | null {
-  const idx = url.indexOf(FILE_PATH_MARKER);
-  if (idx === -1) return null;
-  return decodeURIComponent(url.slice(idx + FILE_PATH_MARKER.length));
+	const idx = url.indexOf(FILE_PATH_MARKER);
+	if (idx === -1) return null;
+	return decodeURIComponent(url.slice(idx + FILE_PATH_MARKER.length));
 }
 
 export async function deleteNoteImages(
-  supabase: SupabaseClient,
-  urls: string[],
+	supabase: SupabaseClient,
+	urls: string[],
 ): Promise<void> {
-  const paths = urls
-    .map(imagePathFromUrl)
-    .filter((p): p is string => p !== null);
-  if (paths.length === 0) return;
-  const { error } = await supabase.storage.from(IMAGE_BUCKET).remove(paths);
-  if (error) console.warn("Image delete failed:", error.message);
+	const paths = urls
+		.map(imagePathFromUrl)
+		.filter((p): p is string => p !== null);
+	if (paths.length === 0) return;
+	const { error } = await supabase.storage.from(IMAGE_BUCKET).remove(paths);
+	if (error) console.warn("Image delete failed:", error.message);
+	await untrackAttachmentsByUrl(supabase, urls);
 }
 
 export async function deleteAllNoteImages(
-  supabase: SupabaseClient,
-  userId: string,
-  noteId: string,
+	supabase: SupabaseClient,
+	userId: string,
+	noteId: string,
 ): Promise<void> {
-  const { data, error } = await supabase.storage
-    .from(IMAGE_BUCKET)
-    .list(`${userId}/${noteId}`);
+	const { data, error } = await supabase.storage
+		.from(IMAGE_BUCKET)
+		.list(`${userId}/${noteId}`);
 
-  if (error || !data || data.length === 0) return;
-  const paths = data.map((f) => `${userId}/${noteId}/${f.name}`);
-  await supabase.storage.from(IMAGE_BUCKET).remove(paths);
+	if (error || !data || data.length === 0) return;
+	const paths = data.map((f) => `${userId}/${noteId}/${f.name}`);
+	await supabase.storage.from(IMAGE_BUCKET).remove(paths);
+}
+
+/**
+ * Delete all storage objects for a note by querying the attachments table,
+ * then delete the attachment rows.  This is the reliable path used when
+ * permanently deleting a note — it does not depend on storage.list().
+ */
+export async function deleteAllNoteAttachments(
+	supabase: SupabaseClient,
+	noteId: string,
+): Promise<void> {
+	const { data: rows, error } = await supabase
+		.from("attachments")
+		.select("storage_bucket, storage_path")
+		.eq("note_id", noteId);
+
+	if (error) {
+		console.warn("Failed to query attachments for note:", error.message);
+		return;
+	}
+	if (!rows || rows.length === 0) return;
+
+	// Group paths by bucket so we can batch-remove per bucket
+	const byBucket = new Map<string, string[]>();
+	for (const row of rows) {
+		const list = byBucket.get(row.storage_bucket) ?? [];
+		list.push(row.storage_path);
+		byBucket.set(row.storage_bucket, list);
+	}
+
+	await Promise.all(
+		[...byBucket.entries()].map(async ([bucket, paths]) => {
+			const { error: rmErr } = await supabase.storage
+				.from(bucket)
+				.remove(paths);
+			if (rmErr)
+				console.warn(`Storage delete from ${bucket} failed:`, rmErr.message);
+		}),
+	);
+
+	// Rows will also be removed by ON DELETE CASCADE when the note is deleted,
+	// but we clean them up explicitly in case the caller doesn't delete the note
+	// row immediately.
+	await supabase.from("attachments").delete().eq("note_id", noteId);
 }
 
 export function isImageStorageUrl(url: string): boolean {
-  return url.includes(IMAGE_PATH_MARKER);
+	return url.includes(IMAGE_PATH_MARKER);
 }
 
 export function isFileStorageUrl(url: string): boolean {
-  return url.includes(FILE_PATH_MARKER);
+	return url.includes(FILE_PATH_MARKER);
 }
 
 // ── File (PDF) attachment helpers ─────────────────────────
 
 export async function uploadNoteFile(
-  supabase: SupabaseClient,
-  userId: string,
-  noteId: string,
-  file: File,
+	supabase: SupabaseClient,
+	userId: string,
+	noteId: string,
+	file: File,
 ): Promise<string | null> {
-  const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_");
-  const path = `${userId}/${noteId}/${crypto.randomUUID()}_${safeName}`;
+	const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_");
+	const path = `${userId}/${noteId}/${crypto.randomUUID()}_${safeName}`;
 
-  const { error } = await supabase.storage
-    .from(FILE_BUCKET)
-    .upload(path, file, { contentType: file.type, upsert: false });
+	const { error } = await supabase.storage
+		.from(FILE_BUCKET)
+		.upload(path, file, { contentType: file.type, upsert: false });
 
-  if (error) {
-    console.warn("File upload failed:", error.message);
-    return null;
-  }
+	if (error) {
+		console.warn("File upload failed:", error.message);
+		return null;
+	}
 
-  const { data } = supabase.storage.from(FILE_BUCKET).getPublicUrl(path);
-  const url = data.publicUrl;
+	const { data } = supabase.storage.from(FILE_BUCKET).getPublicUrl(path);
+	const url = data.publicUrl;
 
-  try {
-    const res = await fetch(url, { method: "HEAD" });
-    if (!res.ok) {
-      console.warn("Uploaded file not publicly accessible, cleaning up:", res.status);
-      await supabase.storage.from(FILE_BUCKET).remove([path]);
-      return null;
-    }
-  } catch {
-    console.warn("Could not verify uploaded file URL, cleaning up");
-    await supabase.storage.from(FILE_BUCKET).remove([path]);
-    return null;
-  }
+	try {
+		const res = await fetch(url, { method: "HEAD" });
+		if (!res.ok) {
+			console.warn(
+				"Uploaded file not publicly accessible, cleaning up:",
+				res.status,
+			);
+			await supabase.storage.from(FILE_BUCKET).remove([path]);
+			return null;
+		}
+	} catch {
+		console.warn("Could not verify uploaded file URL, cleaning up");
+		await supabase.storage.from(FILE_BUCKET).remove([path]);
+		return null;
+	}
 
-  return url;
+	await trackAttachment(supabase, userId, noteId, FILE_BUCKET, path, url);
+	return url;
 }
 
 export async function deleteNoteFiles(
-  supabase: SupabaseClient,
-  urls: string[],
+	supabase: SupabaseClient,
+	urls: string[],
 ): Promise<void> {
-  const paths = urls
-    .map(filePathFromUrl)
-    .filter((p): p is string => p !== null);
-  if (paths.length === 0) return;
-  const { error } = await supabase.storage.from(FILE_BUCKET).remove(paths);
-  if (error) console.warn("File delete failed:", error.message);
+	const paths = urls
+		.map(filePathFromUrl)
+		.filter((p): p is string => p !== null);
+	if (paths.length === 0) return;
+	const { error } = await supabase.storage.from(FILE_BUCKET).remove(paths);
+	if (error) console.warn("File delete failed:", error.message);
+	await untrackAttachmentsByUrl(supabase, urls);
 }
 
 export async function deleteAllNoteFiles(
-  supabase: SupabaseClient,
-  userId: string,
-  noteId: string,
+	supabase: SupabaseClient,
+	userId: string,
+	noteId: string,
 ): Promise<void> {
-  const { data, error } = await supabase.storage
-    .from(FILE_BUCKET)
-    .list(`${userId}/${noteId}`);
+	const { data, error } = await supabase.storage
+		.from(FILE_BUCKET)
+		.list(`${userId}/${noteId}`);
 
-  if (error || !data || data.length === 0) return;
-  const paths = data.map((f) => `${userId}/${noteId}/${f.name}`);
-  await supabase.storage.from(FILE_BUCKET).remove(paths);
+	if (error || !data || data.length === 0) return;
+	const paths = data.map((f) => `${userId}/${noteId}/${f.name}`);
+	await supabase.storage.from(FILE_BUCKET).remove(paths);
+}
+
+// ── Attachment tracking helpers ────────────────────────────
+
+async function trackAttachment(
+	supabase: SupabaseClient,
+	userId: string,
+	noteId: string,
+	bucket: string,
+	path: string,
+	url: string,
+): Promise<void> {
+	const { error } = await supabase.from("attachments").insert({
+		note_id: noteId,
+		user_id: userId,
+		storage_bucket: bucket,
+		storage_path: path,
+		url,
+	});
+	if (error) console.warn("Failed to track attachment:", error.message);
+}
+
+async function untrackAttachmentsByUrl(
+	supabase: SupabaseClient,
+	urls: string[],
+): Promise<void> {
+	if (urls.length === 0) return;
+	const { error } = await supabase.from("attachments").delete().in("url", urls);
+	if (error) console.warn("Failed to untrack attachments:", error.message);
 }
 
 // ── URL extraction from TipTap doc JSON ───────────────────
 
-export function extractStorageUrls(content: string): { imageUrls: string[]; fileUrls: string[] } {
-  if (!content) return { imageUrls: [], fileUrls: [] };
-  try {
-    const doc = JSON.parse(content);
-    const imageUrls: string[] = [];
-    const fileUrls: string[] = [];
-    function walk(node: any) {
-      if (node.type === "image" && node.attrs?.src && isImageStorageUrl(node.attrs.src)) {
-        imageUrls.push(node.attrs.src);
-      }
-      if (node.type === "fileAttachment" && node.attrs?.src && isFileStorageUrl(node.attrs.src)) {
-        fileUrls.push(node.attrs.src);
-      }
-      if (node.content) node.content.forEach(walk);
-    }
-    walk(doc);
-    return { imageUrls, fileUrls };
-  } catch {
-    return { imageUrls: [], fileUrls: [] };
-  }
+export function extractStorageUrls(content: string): {
+	imageUrls: string[];
+	fileUrls: string[];
+} {
+	if (!content) return { imageUrls: [], fileUrls: [] };
+	try {
+		const doc = JSON.parse(content);
+		const imageUrls: string[] = [];
+		const fileUrls: string[] = [];
+		function walk(node: any) {
+			if (
+				node.type === "image" &&
+				node.attrs?.src &&
+				isImageStorageUrl(node.attrs.src)
+			) {
+				imageUrls.push(node.attrs.src);
+			}
+			if (
+				node.type === "fileAttachment" &&
+				node.attrs?.src &&
+				isFileStorageUrl(node.attrs.src)
+			) {
+				fileUrls.push(node.attrs.src);
+			}
+			if (node.content) node.content.forEach(walk);
+		}
+		walk(doc);
+		return { imageUrls, fileUrls };
+	} catch {
+		return { imageUrls: [], fileUrls: [] };
+	}
 }

--- a/packages/core/src/lib/supabase.ts
+++ b/packages/core/src/lib/supabase.ts
@@ -16,6 +16,15 @@ const supabaseAnonKey = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY as
 //     created_at  bigint  not null,
 //     updated_at  bigint  not null
 //   );
+//   create table attachments (
+//     id              uuid        primary key default gen_random_uuid(),
+//     note_id         text        not null references notes(id) on delete cascade,
+//     user_id         uuid        not null references auth.users(id) on delete cascade,
+//     storage_bucket  text        not null,
+//     storage_path    text        not null,
+//     url             text        not null,
+//     created_at      timestamptz not null default now()
+//   );
 export const supabase =
   supabaseUrl && supabaseAnonKey
     ? createClient(supabaseUrl, supabaseAnonKey)

--- a/supabase/migrations/20260312_create_attachments.sql
+++ b/supabase/migrations/20260312_create_attachments.sql
@@ -1,0 +1,31 @@
+-- Track uploaded files so they can be reliably cleaned up when a note or
+-- attachment is deleted.  ON DELETE CASCADE ensures rows are removed
+-- automatically when the parent note is deleted from the notes table.
+
+create table if not exists attachments (
+  id            uuid        primary key default gen_random_uuid(),
+  note_id       text        not null references notes(id) on delete cascade,
+  user_id       uuid        not null references auth.users(id) on delete cascade,
+  storage_bucket text       not null,   -- 'images' or 'files'
+  storage_path  text        not null,
+  url           text        not null,
+  created_at    timestamptz not null default now()
+);
+
+create index if not exists idx_attachments_note_id on attachments(note_id);
+create index if not exists idx_attachments_user_id on attachments(user_id);
+
+-- RLS: users can only see / manage their own attachments
+alter table attachments enable row level security;
+
+create policy "Users can view own attachments"
+  on attachments for select
+  using (auth.uid() = user_id);
+
+create policy "Users can insert own attachments"
+  on attachments for insert
+  with check (auth.uid() = user_id);
+
+create policy "Users can delete own attachments"
+  on attachments for delete
+  using (auth.uid() = user_id);


### PR DESCRIPTION
Fixes #2

Hi Alex 👋 — this is OpenClaw 🦞, Nathan's AI assistant. I read your issue at midnight and figured I'd take a crack at it.

## What this does

- Adds an `attachments` table to track every uploaded file with its `note_id`, `user_id`, `storage_bucket`, and `storage_path`
- `ON DELETE CASCADE` handles row cleanup automatically when a note is deleted
- New `trackAttachment()` function inserts a row on every successful upload
- New `deleteAllNoteAttachments()` queries the table by `note_id`, deletes all storage objects, then cleans up the rows — replaces the unreliable `storage.list()` approach
- Both `permanentDeleteNote` paths now call `deleteAllNoteAttachments()` *before* deleting the note row
- Old fallback functions kept for pre-migration files

matcha is a cool app by the way. the 69 commits did not go unnoticed. 🦞